### PR TITLE
Cosmetic updates to the person_detail page to remove #, sorting, & expansion

### DIFF
--- a/crim/templates/person/person_detail.html
+++ b/crim/templates/person/person_detail.html
@@ -112,10 +112,9 @@
     <table class="table table-bordered table-hover">
       <thead>
         <tr>
-          <th>#</th>
-          <th>ID</th>
-          <th>Model</th>
-          <th>Derivative</th>
+          <th><a href="?rel_order_by=pk">ID</a></th>
+          <th><a href="?rel_order_by=model_observation__piece__piece_id">Model</a></th>
+          <th><a href="?rel_order_by=derivative_observation__piece__piece_id">Derivative</a></th>
           <th>Relationship type</th>
           <th>Show details</th>
         </tr>
@@ -123,7 +122,6 @@
       <tbody>
         {% for relationship in content.relationships %}
           <tr>
-            <td>{{ forloop.counter }}</td>
             <td><a {% if not relationship.curated %}class="uncurated"{% endif %} href="{{ relationship.url|htmlsite }}">&lt;R{{ relationship.id }}&gt;</a></td>
             <td>
               <a {% if not relationship.curated %}class="uncurated"{% endif %} href="{{ relationship.model_observation.url|htmlsite }}">
@@ -152,16 +150,29 @@
               <a href="#" class="relationship-info-expand {% if not relationship.curated %}uncurated{% endif %}" target="relationship-info-{{ forloop.counter }}">Expand</a>
             </td>
           </tr>
-          <!--
           <tr id="relationship-info-{{ forloop.counter }}" class="relationship-info">
             <td colspan="6" class="expansion">
               {% include "relationship/relationship_expanded.html" %}
             </td>
           </tr>
-           -->
         {% endfor %}
       </tbody>
     </table>
+
+    <script type="text/javascript">
+      // This script expands and hides relationship details
+      $('.relationship-info').hide();
+      $('.relationship-info-expand').on({
+        'click': function(event) {
+          event.preventDefault();
+          tgt = "#" + $(this).attr('target');
+          $(tgt).toggle();
+          tag = $(this).text() == "Expand" ? "Collapse" : "Expand";
+          $(this).text(tag);
+          return false;
+        }
+      })
+    </script>  
   {% endif %}
 
 {% endblock %}

--- a/crim/views/person.py
+++ b/crim/views/person.py
@@ -80,7 +80,14 @@ class PersonDetail(generics.RetrieveAPIView):
         PersonDetailHTMLRenderer,
         JSONRenderer,
     )
-    queryset = CRIMPerson.objects.all()
+
+    def get_queryset(self):
+        queryset = CRIMPerson.objects.all()
+        order_by = self.request.GET.get('order_by', 'pk')
+        queryset.prefetch_related().order_by(order_by)
+
+        return queryset
+
 
     def get_object(self):
         url_arg = self.kwargs['person_id']


### PR DESCRIPTION
Cosmetic updates as requested to the person_detail page to remove the unnecessary # column, add header sorting to the relationship list table, & fix the scripts on the expand column in the relationship list table. 