### PR TITLE
Add sortable header to relationship list

### DIFF
--- a/crim/templates/person/person_detail.html
+++ b/crim/templates/person/person_detail.html
@@ -113,7 +113,6 @@
     <table class="table table-bordered table-hover">
       <thead>
         <tr>
-          
           <th>{% sortable_header "ID" "rel_order" "pk" True %}</th>
           <th>{% sortable_header "Model" "rel_order" "model_observation__piece__piece_id" %}</th>
           <th>{% sortable_header "Derivative" "rel_order" "derivative_observation__piece__piece_id" %}</th>

--- a/crim/templates/person/person_detail.html
+++ b/crim/templates/person/person_detail.html
@@ -113,6 +113,7 @@
     <table class="table table-bordered table-hover">
       <thead>
         <tr>
+          
           <th>{% sortable_header "ID" "rel_order" "pk" True %}</th>
           <th>{% sortable_header "Model" "rel_order" "model_observation__piece__piece_id" %}</th>
           <th>{% sortable_header "Derivative" "rel_order" "derivative_observation__piece__piece_id" %}</th>

--- a/crim/templates/relationship/relationship_list.html
+++ b/crim/templates/relationship/relationship_list.html
@@ -3,6 +3,7 @@
 {% load shorten %}
 {% load static %}
 {% load get_string %}
+{% load sortable_header %}
 
 {% block title %}
   <title>CRIM | Relationships</title>
@@ -23,10 +24,11 @@
       <table class="table table-bordered table-hover">
         <thead>
           <tr>
-            <th><a href="?order_by=pk">ID</a></th>
-            <th><a href="?order_by=observer__name_sort">Observer</a></th>
-            <th><a href="?order_by=model_observation__piece__piece_id">Model</a></th>
-            <th><a href="?order_by=derivative_observation__piece__piece_id">Derivative</a></th>
+            <th>{% sortable_header "ID" "order_by" "pk" True %}</th>
+            <th>{% sortable_header "Observer" "order_by" "observer__name_sort" %}</th>
+            <th>{% sortable_header "Model" "order_by" "model_observation__piece__piece_id" %}</th>
+            <th>{% sortable_header "Derivative" "order_by" "derivative_observation__piece__piece_id" %}</th>
+            
             <th>Relationship type</th>
             <th>Show details</th>
           </tr>

--- a/crim/templatetags/sortable_header.py
+++ b/crim/templatetags/sortable_header.py
@@ -3,13 +3,15 @@ from django.utils.safestring import mark_safe
 
 register  = template.Library()
 
+UP_ARROW = '&#9650;'
+DN_ARROW = '&#9660;'
+
 @register.simple_tag(takes_context=True)
 def sortable_header(context, title, param, value, default = False):
     request = context['request']
     qparam = request.GET.get(param, '')
     if (default and qparam == '') or (qparam == value):
-        title, value = f'{title} &#9660;', f'-{value}'
+        title, value = f'{title} {UP_ARROW}', f'-{value}'
     elif qparam == f'-{value}':
-        title = f'{title} &#9650;'
+        title = f'{title} {DN_ARROW}'
     return mark_safe(f'<a href="?{param}={value}">{title}</a>')
-


### PR DESCRIPTION
I have done the following:

* Pulled the arrow constants out of the embedded text in sortable_header so it is clearer which is which
* Reversed the up & down arrow characters in sortable_header per request
* Cleaned up the sortable_header custom tag for use in other situations than just table headers
* Updated the person_detail page to reflect the usage changes in sortable_header* Applied sortable_header to the relationship_list page
