### PR TITLE
Relation edit page

### DIFF
--- a/crim/templates/observation/observation_detail.html
+++ b/crim/templates/observation/observation_detail.html
@@ -8,6 +8,7 @@
 {% load firstitem %}
 {% load people %}
 {% load is_owner %}
+{% load observation_type %}
 
 {% block title %}
   <title>
@@ -21,6 +22,29 @@
 
 {% block wrap %}
   <hgroup class="page-title">
+
+    <!-- COPY MODAL -->
+    <div class="modal hide fade" id="copy_modal">
+      <!-- FIXME: Correct this so it does the right thing and shows the right options -->
+      <div class="modal-header">
+        <button class="close" data-dismiss="modal">×</button>
+        <h3>Duplicate this Observation as</h3>
+      </div>
+      <form id="copy-modal-form" >
+        <div class="modal-body" >
+          <input name="observation-type" id="observation-type" type="hidden" value="{{ content|observation_type }}" required >
+          <input class="form-check-input" type="radio" name="observation-type" id="observation-type-model" value="model" {% if content.relationships_as_model|length %}checked{% endif %} >
+          <label class="form-check-label" for="observation-type-model">Model</label>
+          <input class="form-check-input" type="radio" name="observation-type" id="observation-type-deriv" value="derivative" {% if content.relationships_as_derivative|length %}checked{% endif %} >
+          <label class="form-check-label" for="observation-type-deriv">Derivative</label>
+        </div>
+        <div class="modal-footer">
+          <input class="btn btn-primary" type="submit" name="copy_modal_submit" id="copy_modal_submit" value="Duplicate" >
+          <input class="btn btn-cancel" type="button" name="copy_modal_close" id="copy_modal_close" value="Close" data-dismiss="modal" >
+        </div>
+      </form>
+    </div>      
+
     <h1>
       {% if content.curated %}Observation{% else %}Uncurated observation{% endif %} <small>&lt;{{ content.id }}&gt;</small>
       <!-- {{ content.observer }} -->
@@ -29,7 +53,7 @@
       <small><a href="/observations/{{ content.id }}/edit/" >[Edit this observation]</a></small>
       {% endif %}
       <br />
-      <small><a href="/observations/{{ content.id }}/copy/" >[Duplicate this observation]</a></small>
+      <small><a href="#copy_modal" data-toggle="modal" >[Duplicate this observation]</a></small>
     </h1>
     <h2>Observer: <a href="{{ content.observer.url|htmlsite }}">{{ content.observer.name }}</a></h2>
     {% for relationship in content.relationships_as_model %}
@@ -118,6 +142,31 @@
     document.addEventListener("DOMContentLoaded", (event) => {
       setScore('score_container', 'observation_score', 'score_nav', mei, '{{content.ema}}')
     });
+
+    // make checkboxes true false value
+    $("input:radio").change(function () {
+      const elem = $(this);
+      elem.parent().find('input:hidden').val(elem.val());
+    });
+
+    $(document).ready(function() {
+      $('#copy_modal').modal({ keyboard: true, backdrop: true, show: false });
+    });
+
+    
+    const modal_form = document.getElementById('copy-modal-form');
+    modal_form.addEventListener('submit', copyModalSubmit);
+    const input_observation_type = document.getElementById('observation-type');
+    
+    async function copyModalSubmit(event) {
+      event.preventDefault();
+
+      const type = input_observation_type.value;
+
+      const url = `/observations/{{ content.id }}/copy/?type=${type}`;
+
+      window.location.assign(url);
+    }
 
   </script>
 

--- a/crim/templates/person/person_detail.html
+++ b/crim/templates/person/person_detail.html
@@ -7,6 +7,7 @@
 {% load newlinereplace %}
 {% load format_role_types %}
 {% load sortable_header %}
+{% load curated_filter %}
 
 {% block title %}
   <title>CRIM | {{ content.name }}</title>
@@ -110,6 +111,8 @@
   <!-- TODO: Update this to function in a manner more conducive to how you like -->
   {% if content.relationships %}
     <h2>Relationships ({{ content.relationships|length }})</h2>
+    <!-- CURATED RELATIONSHIPS -->
+    <h3>Curated ({{ content.relationships|curated_count }})</h3>
     <table class="table table-bordered table-hover">
       <thead>
         <tr>
@@ -122,7 +125,59 @@
         </tr>
       </thead>
       <tbody>
-        {% for relationship in content.relationships %}
+        {% for relationship in content.relationships|filter_curated %}
+          <tr>
+            <td><a {% if not relationship.curated %}class="uncurated"{% endif %} href="{{ relationship.url|htmlsite }}">&lt;R{{ relationship.id }}&gt;</a></td>
+            <td>
+              <a {% if not relationship.curated %}class="uncurated"{% endif %} href="{{ relationship.model_observation.url|htmlsite }}">
+                &lt;{{ relationship.model_observation.id }}&gt;
+              </a>
+              <a {% if not relationship.curated %}class="uncurated"{% endif %} href="{{ relationship.model_observation.piece.url|htmlsite }}">
+                {{ relationship.model_observation.piece.full_title }}
+              </a>
+            </td>
+            <td>
+              <a {% if not relationship.curated %}class="uncurated"{% endif %} href="{{ relationship.derivative_observation.url|htmlsite }}">
+                &lt;{{ relationship.derivative_observation.id }}&gt;
+              </a>
+              <a {% if not relationship.curated %}class="uncurated"{% endif %} href="{{ relationship.derivative_observation.piece.url|htmlsite }}">
+                {{ relationship.derivative_observation.piece.full_title }}
+              </a>
+            </td>
+            <td>
+              {% if relationship.relationship_type %}
+                {{ relationship.relationship_type|capitalize }}
+              {% else %}
+                None
+              {% endif %}
+            </td>
+            <td>
+              <a href="#" class="relationship-info-expand {% if not relationship.curated %}uncurated{% endif %}" target="relationship-info-{{ forloop.counter }}">Expand</a>
+            </td>
+          </tr>
+          <tr id="relationship-info-{{ forloop.counter }}" class="relationship-info">
+            <td colspan="6" class="expansion">
+              {% include "relationship/relationship_expanded.html" %}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <!-- UNCURATED RELATIONSHIPS -->
+    <h3>Uncurated ({{ content.relationships|uncurated_count }})</h3>
+    <table class="table table-bordered table-hover">
+      <thead>
+        <tr>
+          <th>{% sortable_header "ID" "rel_order" "pk" True %}</th>
+          <th>{% sortable_header "Model" "rel_order" "model_observation__piece__piece_id" %}</th>
+          <th>{% sortable_header "Derivative" "rel_order" "derivative_observation__piece__piece_id" %}</th>
+
+          <th>Relationship type</th>
+          <th>Show details</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for relationship in content.relationships|filter_uncurated %}
           <tr>
             <td><a {% if not relationship.curated %}class="uncurated"{% endif %} href="{{ relationship.url|htmlsite }}">&lt;R{{ relationship.id }}&gt;</a></td>
             <td>

--- a/crim/templates/relationship/relationship_edit.html
+++ b/crim/templates/relationship/relationship_edit.html
@@ -79,9 +79,9 @@
           {% for type in relationship_definition %}
             <!-- {{ type.name }} == {{ relationship.relationship_type }} -->
             {% if type.name == relationship.relationship_type %}
-              <li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#relationship-{{ type.name|slugify }}">{{ type.name.capitalize }}</a></li>
+                <li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#relationship-{{ type.name|slugify }}" data-rel-type="{{ type.name }}" >{{ type.name.capitalize }}</a></li>
             {% else %}
-              <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#relationship-{{ type.name|slugify }}">{{ type.name.capitalize }}</a></li>
+                <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#relationship-{{ type.name|slugify }}" data-rel-type="{{ type.name }}" >{{ type.name.capitalize }}</a></li>
             {% endif %}
           {% endfor %}
         </ul>
@@ -93,7 +93,7 @@
           {% for type in relationship_definition %}
             {% with rel_details=relationship|get_rel_details:type.name %}
               <!-- {{ rel_details }} {{ rel_details|obj_type }} {{ type.name }} -->
-              <div class="tab-pane container fade {% if type.name == relationship.relationship_type %}show active{% endif %}" id="relationship-{{ type.name|slugify }}">
+                <div class="tab-pane container fade {% if type.name == relationship.relationship_type %}show active{% endif %}" id="relationship-{{ type.name|slugify }}" data-rel-type="{{ type.name }}" >
                 <div class="relationship-{{ type.name|slugify }}"></div>
                 {% for subtype in type.subtypes %}
                   {% with detail_value=rel_details|lookup:subtype.name %}
@@ -689,8 +689,6 @@
                 const [ kind, [ dataKey, tabClass ] ] = entry;
                 const activeTabs = $(`.${kind} .tab-content`).find('.active');
                 if (activeTabs.length > 0) {
-                    // Set the value for the active tab
-                    $(`#${kind}-selected-tab`).val(activeTabs.data(dataKey));
                     // Validate the initial active tab
                     validateTab(activeTabs[0]);
                 }
@@ -914,12 +912,13 @@
                 "X-CSRFToken": massagedData['csrfmiddlewaretoken']
               },
               success: function(response){
-                console.log(stringData);
                 console.log(response);
-                alert("Data was succesfully captured");
+                const id = response.id;
+                const url = `/relationships/${id}/`;
+                console.log(`Data was succesfully captured: ${id}`);
+                window.location.assign(url);
               },
               error: function(response){
-                console.log(stringData);
                 console.log(response);
                 if (response.status == 401) {
                   alert('You do not have permission to complete the requested operation');

--- a/crim/templates/relationship/relationship_form.html
+++ b/crim/templates/relationship/relationship_form.html
@@ -70,13 +70,13 @@
               {% for subtype in type.subtypes %}
                 {% if subtype.form == "boolean" %}
                   <div class="form-check">
-                    <input class="form-check-input" type='checkbox' name="relationship-{{ type.name|concat_str:subtype.name }}" value='true' id="relationship-{{ type.name|concat_str:subtype.name }}">
-                    <input name="relationship-{{ type.name|concat_str:subtype.name }}" type='hidden' value='false'>
-                    <label class='form-check-label' for="relationship-{{ type.name|concat_str:subtype.name }}">{{ subtype.name.capitalize }}</label>
+                    <input class="form-check-input" type='checkbox' name="relationship-{{ type.name|concat_str:subtype.name }}" value="true" id="relationship-{{ type.name|concat_str:subtype.name }}">
+                    <input name="relationship-{{ type.name|concat_str:subtype.name }}" type="hidden" value="false">
+                    <label class="form-check-label" for="relationship-{{ type.name|concat_str:subtype.name }}">{{ subtype.name.capitalize }}</label>
                   </div>
 
                 {% elif subtype.form == "radio" %}
-                  <input name="relationship-{{ type.name|concat_str:subtype.name }}" type='hidden' value='null'>
+                  <input name="relationship-{{ type.name|concat_str:subtype.name }}" type="hidden" value="null">
                   {{ subtype.name.capitalize }}:
                   <div id="relationship-{{ type.name|concat_str:subtype.name }}" style="margin-left:50px;">
                     {% for option in subtype.options %}

--- a/crim/templatetags/curated_filter.py
+++ b/crim/templatetags/curated_filter.py
@@ -1,0 +1,21 @@
+from django.template.defaulttags import register
+
+@register.filter(name='filter_curated')
+def filter_curated(list):
+    for item in list:
+        if item['curated']:
+            yield item
+
+@register.filter(name='curated_count')
+def curated_count(list):
+    return sum(1 for item in list if item['curated'])
+
+@register.filter(name='filter_uncurated')
+def filter_uncurated(list):
+    for item in list:
+        if not item['curated']:
+            yield item
+
+@register.filter(name='uncurated_count')
+def uncurated_count(list):
+    return sum(1 for item in list if not item['curated'])

--- a/crim/templatetags/observation_type.py
+++ b/crim/templatetags/observation_type.py
@@ -1,0 +1,7 @@
+from django.template.defaulttags import register
+
+@register.filter(name='observation_type')
+def observation_type(content):
+    is_model = len(content['relationships_as_model']) > 0
+    # is_deriv = len(content['relationships_as_derivative']) > 0
+    return "model" if is_model else "derivative"

--- a/crim/views/relationship.py
+++ b/crim/views/relationship.py
@@ -67,9 +67,9 @@ def generate_relationship_data(request):
                 return Response({'serialized': serialized_derivative, 'content': derivative_observation})
 
     # Wait to save observations till now, which is when we know that the entire POST will succeed
-    if not post_data('model_observation_id') and post_data('model_piece'):
+    if serialized_model != None:
         serialized_model.save()
-    if not post_data('derivative_observation_id') and post_data('derivative_piece'):
+    if serialized_derivative != None:
         serialized_derivative.save()
 
     if post_data('model_observation_id') or post_data('model_piece'):

--- a/crim/views/relationship.py
+++ b/crim/views/relationship.py
@@ -25,6 +25,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+
 def generate_relationship_data(request):
     def post_data(v):
         return request.data.get(v)


### PR DESCRIPTION
I have fixed the errors that Richard was seeing with the observation details not being properly saved, and the kind being lost in certain circumstances.

I have also add in a modal to the observation_detail page so a user can choose between `model` and `derivative` when duplicating an observation.

In addition I have updated the person_detail page to split the relationship tables into two tables of curated and uncurated.