### PR TITLE
person_details page publish button auth fix

### DIFF
--- a/crim/views/relationship.py
+++ b/crim/views/relationship.py
@@ -426,12 +426,12 @@ class RelationshipPublishData(generics.UpdateAPIView):
         if not curr_user.is_authenticated or not curr_user.profile.person:
             return Response(status=status.HTTP_401_UNAUTHORIZED)
 
-        # Deny users the ability to update models they do not own
-        if not curr_user.is_superuser and (curr_user.profile.person.person_id != request.data.get('observer')):
-            return Response(status=status.HTTP_401_UNAUTHORIZED)
-
         instance = self.get_object()
         
+        # Deny users the ability to update models they do not own
+        if not curr_user.is_superuser and (curr_user.profile.person.person_id != instance.observer.person_id):
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
+
         is_curated = post_data('curated')
 
         curate_observation(instance.model_observation, is_curated)


### PR DESCRIPTION
This patch addresses an issue with the person details publish API endpoint, whereby a user will be told they are unauthorized to publish a relationship they clearly are authorized to publish.
I have updated the auth endpoint to look at the observer that owns the instance instead of the incorrect request parameter it was looking at before, and comparing that to who is logged into the system.