### PR TITLE
Updated many of the headers to use the sortable_header templatetag

### DIFF
--- a/crim/templates/mass/mass_list.html
+++ b/crim/templates/mass/mass_list.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% load markdown %}
 {% load shorten %}
+{% load sortable_header %}
+
+
 
 {% block title %}
   <title>CRIM | Masses</title>
@@ -21,11 +24,11 @@
       <table class="table table-white table-bordered table-hover">
         <thead>
           <tr>
-            <th><a href="?order_by=mass_id">Mass ID</a></th>
-            <th><a href="?order_by=title">Title</a></th>
-            <th><a href="?order_by=composer__name_sort">Composer</a></th>
-            <th><a href="?order_by=max_number_of_voices">Voices</a></th>
-            <th><a href="?order_by=date_sort">Date</a></th>
+            <th>{% sortable_header "Mass ID" "order_by" "mass_id" True %}</th>
+            <th>{% sortable_header "Title" "order_by" "title" %}</th>
+            <th>{% sortable_header "Composer" "order_by" "composer__name_sort" %}</th>
+            <th>{% sortable_header "Voices" "order_by" "max_number_of_voices" %}</th>
+            <th>{% sortable_header "Date" "order_by" "date_sort" %}</th>
           </tr>
         </thead>
         <tbody>

--- a/crim/templates/observation/observation_list.html
+++ b/crim/templates/observation/observation_list.html
@@ -3,6 +3,9 @@
 {% load shorten %}
 {% load static %}
 {% load get_string %}
+{% load sortable_header %}
+
+
 
 {% block title %}
   <title>CRIM | Observations</title>
@@ -23,9 +26,9 @@
       <table class="table table-bordered table-hover">
         <thead>
           <tr>
-            <th><a href="?order_by=pk">ID</a></th>
-            <th><a href="?order_by=observer__name_sort">Observer</a></th>
-            <th><a href="?order_by=piece__piece_id">Piece</a></th>
+            <th>{% sortable_header "ID" "order_by" "pk" True %}</th>
+            <th>{% sortable_header "Observer" "order_by" "observer__name_sort" %}</th>
+            <th>{% sortable_header "Piece" "order_by" "piece__piece_id" %}</th>
             <th>Observation type</th>
             <th>Show details</th>
           </tr>

--- a/crim/templates/person/person_list.html
+++ b/crim/templates/person/person_list.html
@@ -5,6 +5,9 @@
 {% load shortendate %}
 {% load get_string %}
 {% load format_role_types %}
+{% load sortable_header %}
+
+
 
 {% block title %}
   <title>CRIM | {% if content.filter_role_type %}People: {{ content.filter_role_type.name_plural }}{% else %}People{% endif %}</title>
@@ -34,10 +37,10 @@
       <table class="table table-white table-bordered table-hover">
         <thead>
           <tr>
-            <th><a href="?order_by=person_id">Person ID</a></th>
-            <th><a href="?order_by=name_sort">Name</a></th>
-            <th><a href="?order_by=date_sort">Dates</a></th>
-            <th><a href="?order_by=role">Roles</a></th>
+            <th>{% sortable_header "Person ID" "order_by" "person_id" True %}</th>
+            <th>{% sortable_header "Name" "order_by" "name_sort" %}</th>
+            <th>{% sortable_header "Dates" "order_by" "date_sort" %}</th>
+            <th>{% sortable_header "Roles" "order_by" "role" %}</th>
             <th>Alternate Names</th>
           </tr>
         </thead>

--- a/crim/templates/piece/all_piece_list.html
+++ b/crim/templates/piece/all_piece_list.html
@@ -3,6 +3,9 @@
 {% load shorten %}
 {% load static %}
 {% load get_string %}
+{% load sortable_header %}
+
+
 
 {% block title %}
   <title>CRIM | {% if content.filter_genre %}Pieces: {{ content.filter_genre.name_plural }}{% else %}Pieces (all){% endif %}</title>
@@ -32,12 +35,12 @@
       <table class="table table-white table-bordered table-hover">
         <thead>
           <tr>
-            <th><a href="?order_by=piece_id">Piece ID</a></th>
-            <th><a href="?order_by=full_title">Title</a></th>
-            <th><a href="?order_by=composer__name_sort">Composer</a></th>
-            <th><a href="?order_by=genre">Genre</a></th>
-            <th><a href="?order_by=number_of_voices">Voices</a></th>
-            <th><a href="?order_by=date_sort">Date</a></th>
+            <th>{% sortable_header "Piece ID" "order_by" "piece_id" True %}</th>
+            <th>{% sortable_header "Title" "order_by" "full_title" %}</th>
+            <th>{% sortable_header "Composer" "order_by" "composer__name_sort" %}</th>
+            <th>{% sortable_header "Genre" "order_by" "genre" %}</th>
+            <th>{% sortable_header "Voices" "order_by" "number_of_voices" %}</th>
+            <th>{% sortable_header "Date" "order_by" "date_sort" %}</th>
           </tr>
         </thead>
         <tbody>

--- a/crim/templates/piece/model_list.html
+++ b/crim/templates/piece/model_list.html
@@ -2,6 +2,9 @@
 {% load markdown %}
 {% load shorten %}
 {% load static %}
+{% load sortable_header %}
+
+
 
 {% block title %}
 <title>CRIM | Models</title>
@@ -22,12 +25,12 @@
     <table class="table table-white table-bordered table-hover">
       <thead>
         <tr>
-          <th><a href="?order_by=piece_id">Piece ID</a></th>
-          <th><a href="?order_by=full_title">Title</a></th>
-          <th><a href="?order_by=composer__name_sort">Composer</a></th>
-          <th><a href="?order_by=genre">Genre</a></th>
-          <th><a href="?order_by=number_of_voices">Voices</a></th>
-          <th><a href="?order_by=date_sort">Date</a></th>
+          <th>{% sortable_header "Piece ID" "order_by" "piece_id" True %}</th>
+          <th>{% sortable_header "Title" "order_by" "full_title" %}</th>
+          <th>{% sortable_header "Composer" "order_by" "composer__name_sort" %}</th>
+          <th>{% sortable_header "Genre" "order_by" "genre" %}</th>
+          <th>{% sortable_header "Voices" "order_by" "number_of_voices" %}</th>
+          <th>{% sortable_header "Date" "order_by" "date_sort" %}</th>
         </tr>
       </thead>
       <tbody>

--- a/crim/templates/source/source_list.html
+++ b/crim/templates/source/source_list.html
@@ -2,6 +2,9 @@
 {% load markdown %}
 {% load shorten %}
 {% load static %}
+{% load sortable_header %}
+
+
 
 {% block title %}
   <title>CRIM | Sources</title>
@@ -22,10 +25,10 @@
       <table class="table table-white table-bordered table-hover">
         <thead>
           <tr>
-            <th><a href="?order_by=document_id">Document ID</a></th>
-            <th><a href="?order_by=title">Title</a></th>
-            <th><a href="?order_by=publisher__name_sort">Publisher</a></th>
-            <th><a href="?order_by=date_sort">Date</a></th>
+            <th>{% sortable_header "Document ID" "order_by" "document_id" True %}</th>
+            <th>{% sortable_header "Title" "order_by" "title" %}</th>
+            <th>{% sortable_header "Publisher" "order_by" "publisher__name_sort" %}</th>
+            <th>{% sortable_header "Date" "order_by" "date_sort" %}</th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
I have updated many of the tables on the main lists pages to be sortable headers, this will allow them to be sorted A-Z and Z-A and showing the direction indicator.