### PR TITLE
Added initial pass at setup docs and data-load script

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,41 @@
+HOWTO: CRIMOnline local development setup
+------
+1. Clone the repository to your local environment
+2. Create a virtual environment for the project
+  - Excute `python3 -m venv venv`
+  - NOTE: The second `venv` is the name of the directory the virtual environment will be installed into
+3. Activate the virtual environment
+  - Execute `source venv/bin/activate`
+  - **NOTE: When working with the project you will need to activate the virtual environment each time you open a new console**
+4. Open the `requirements.txt` for editing and comment out the `psycopg2` package prefixing the line with the `#` character.
+5. Install the project requirements within the virtual environment
+  - Execute `pip install -r requirements.txt`
+5. Copy or symbolicly link the file `crim/settings_development.py` to `crim/settings_production.py`
+6. Create the django database migrations (this will generate the database model descriptions)
+  - Execute `python3 ./manage.py makemigrations`
+7. Migrate the django models to the database (this will create the tables in the database)
+  - Execute `python3 ./manage.py migrate`
+  
+8. Load a recent data dump for some local test data (NOTE: Data must be imported in the exact order)
+  - python3 ./manage.py loaddata <filename>
+  - crim/fixtures/data-2020/1.json
+  - crim/fixtures/data-2020/2.json
+  - crim/fixtures/data-2020/3.json
+  - crim/fixtures/data-2020/4.json
+  - crim/fixtures/data-2020/5.json
+  - crim/fixtures/data-2020/6.json
+  - crim/fixtures/data-2020/7.json
+  - crim/fixtures/data-2020/8.json
+  - crim/fixtures/data-2022/definitions.json
+  - crim/fixtures/data-2022-fresh/definition.json
+  - crim/fixtures/data-2022-fresh/person.json
+  - ???
+  - definition.json
+  - genre
+  - person
+  - roletype
+  - 
+
+
+9. Start the server with `python3 ./manage.py runserver` (the virtual environment needs to be active).
+10. Start a shell with `python3 ./manage.py shell` (the virtual environment needs to be active).

--- a/crim/settings_development.py
+++ b/crim/settings_development.py
@@ -1,0 +1,104 @@
+# Database
+# https://docs.djangoproject.com/en/2.0/ref/settings/#databases
+
+SITE_ID = 2
+
+ALLOWED_HOSTS = (
+    '127.0.0.1',
+)
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'crim.dev.sqlite3',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
+    }
+}
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'DEBUG',
+    },
+}
+
+SOLR_SERVER = 'http://localhost:8983/solr/crim'
+
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 10240
+
+CORS_ORIGIN_ALLOW_ALL = True
+
+ALLOWED_HOSTS = [
+    "crimproject.com",
+    "127.0.0.1"
+]
+CORS_ALLOWED_ORIGINS = [
+    "https://crimproject.com",
+    "http://127.0.0.1:8000"
+]
+
+CORS_ALLOW_METHODS = [
+    'GET',
+    'OPTIONS',
+]
+
+# This value is a placeholder for development
+SECRET_KEY = "development.environment"
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '~/crim-cache-default/',
+        'OPTIONS': {
+            'MAX_ENTRIES': 6000,
+        },
+        'TIMEOUT': None,
+    },
+    'pieces': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '~/crim-cache-pieces',
+        'OPTIONS': {
+            'MAX_ENTRIES': 6000,
+        },
+        'TIMEOUT': None,
+    },
+    'observations': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '~/crim-cache-observations',
+        'OPTIONS': {
+            'MAX_ENTRIES': 600000,
+        },
+        'TIMEOUT': None,
+    },
+    # 'highlights': {
+    #     'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+    #     'LOCATION': '/Users/jchthys/crim-cache-highlights',
+    #     'OPTIONS': {
+    #         'MAX_ENTRIES': 12000,
+    #     },
+    #     'TIMEOUT': None,
+    # },
+}
+
+INTERNAL_IPS = [
+    # ...
+    '127.0.0.1',
+    # ...
+]
+
+# This value is a placeholder for development of the application
+ADMIN_EMAIL = 'development@crimonline.org'
+

--- a/data-load.py
+++ b/data-load.py
@@ -1,0 +1,49 @@
+
+import os
+import sys
+
+# def iterate(path, command):
+#   if os.path.isfile(path) and path.endswith('.json'):
+#     command(path)
+#   elif os.path.isdir(path):
+#     for filename in os.listdir(path):
+#       iterate(os.path.join(path, filename), command)
+
+
+
+# def load_data(file):
+#   command = f'python3 ./manage.py loaddata {file}'
+#   # print(command)
+#   os.system(f'python3 ./manage.py loaddata {file}')
+
+if __name__ == '__main__':
+  # if len(sys.argv) < 2:
+  #   print("usage: data-load.py <path>")
+  #   sys.exit(-1)
+
+  # path = sys.argv[1]
+  # iterate(path, load_data)
+
+  path = 'crim/fixtures/data-2022-fresh'
+  items = [ 'genre.json',
+            'mass.json',
+            'piece.json',
+            'part.json',
+            'phrase.json',
+            'voice.json',
+            'treatise.json',
+            'source.json',
+            'person.json',
+            'roletype.json',
+            'role.json',
+            'definition.json',
+            'observation.json',
+            'relationship.json',
+          ]
+  for filename in items:
+    file = os.path.join(path, filename)
+    os.system('python3 ./manage.py makemigrations')
+    os.system('python3 ./manage.py migrate')
+    os.system(f'python3 ./manage.py loaddata {file}')
+    # if os.system(f'python3 ./manage.py loaddata {file}') != 0:
+    #   sys.exit(-1)

--- a/data-load.py
+++ b/data-load.py
@@ -17,14 +17,14 @@ import sys
 #   os.system(f'python3 ./manage.py loaddata {file}')
 
 if __name__ == '__main__':
-  # if len(sys.argv) < 2:
-  #   print("usage: data-load.py <path>")
-  #   sys.exit(-1)
+  if len(sys.argv) < 2:
+    print("usage: data-load.py <path>")
+    sys.exit(-1)
 
-  # path = sys.argv[1]
+  # path = 'crim/fixtures/data-2022-fresh'
+  path = sys.argv[1]
   # iterate(path, load_data)
 
-  path = 'crim/fixtures/data-2022-fresh'
   items = [ 'genre.json',
             'mass.json',
             'piece.json',


### PR DESCRIPTION
I have added a bit of setup documentation and a script to help perform an initial load of the data into the database.

This is a first pass at better document the local setup process to make it simpler/easier for folks to get onboarded and help out with the project.

The `settings_development.py` configuration file has some basic settings based on the CRIM production values with some saner values for development turning on additional debugging settings these SHOULD NOT be used in any production environment, but do assist with development.

The `data-load.py` script can load JSON content into the database it will make the migrations perform the migrations and then attempt to load the specified scripts into the database.  The script takes a single argument which is a path to the JSON data.  Then it attempts to load that data into the database in the order specified in the script, looking for files with the specified names in the items list.  Also the items will be imported in the specified order, which may or may not be the correct order for importing that data into the database.

Please review this content before merging into the project so we can discuss if any updates or clarifications are necessary.  Thank you.