### PR TITLE
Updated continuo.js with correct verovio api call.

### DIFF
--- a/crim/settings_development.py
+++ b/crim/settings_development.py
@@ -3,10 +3,6 @@
 
 SITE_ID = 2
 
-ALLOWED_HOSTS = (
-    '127.0.0.1',
-)
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -39,14 +35,16 @@ SOLR_SERVER = 'http://localhost:8983/solr/crim'
 
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10240
 
+CORS_ALLOW_ALL_ORIGINS = True
 CORS_ORIGIN_ALLOW_ALL = True
 
-ALLOWED_HOSTS = [
-    "crimproject.com",
-    "127.0.0.1"
-]
 CORS_ALLOWED_ORIGINS = [
-    "https://crimproject.com",
+    "https://crimproject.org",
+    "http://127.0.0.1:8000"
+]
+
+CSRF_TRUSTED_ORIGINS = [
+    "https://crimproject.org",
     "http://127.0.0.1:8000"
 ]
 

--- a/crim/static/continuo.js
+++ b/crim/static/continuo.js
@@ -28034,7 +28034,8 @@ var Continuo = function (_Backbone$View) {
 
             if (this.paginate) {
                 this.page = 1;
-                var svg = vrvToolkit.renderPage(1);
+                // var svg = vrvToolkit.renderPage(1);
+                var svg = vrvToolkit.renderToSVG(1);
                 var ext_svg = (0, _verovioExt2.default)(svg);
                 container.append(ext_svg);
             } else {
@@ -28049,7 +28050,8 @@ var Continuo = function (_Backbone$View) {
                     })[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
                         var page = _step.value;
 
-                        var _svg = vrvToolkit.renderPage(page + 1);
+                        // var _svg = vrvToolkit.renderPage(page + 1);
+                        var _svg = vrvToolkit.renderToSVG(page + 1);
 
                         var _ext_svg = (0, _verovioExt2.default)(_svg);
                         container.append(_ext_svg);
@@ -28200,7 +28202,8 @@ var Continuo = function (_Backbone$View) {
             this.vrvToolkit.loadData(meidata)
             if (page > 0 && page <= this.vrvToolkit.getPageCount()) {
                 this.page = page;
-                var svg = this.vrvToolkit.renderPage(page);
+                // var svg = this.vrvToolkit.renderPage(page);
+                var svg = this.vrvToolkit.renderToSVG(page);
                 var ext_svg = (0, _verovioExt2.default)(svg);
                 this.$el.find(".cnt-container > svg").replaceWith(ext_svg);
 

--- a/crim/templates/relationship/relationship_form.html
+++ b/crim/templates/relationship/relationship_form.html
@@ -624,7 +624,8 @@
                 $('#buttonModelContinuo').text('Hide music notation');
                 $('#collapseDerivativeContinuo').collapse('hide');
                 MEIurl = $("#model-piece option:selected").data('piece-url')
-                // MEIurl = MEIurl.replace('https://crim', 'https://dev.crim')
+                // XXX: Use this line for local development only
+                // MEIurl = MEIurl.replace('https://crimproject.org/mei/', 'http://127.0.0.1:8000/static/mei/MEI_4.0/')
                 if (!ver) {
                     console.log('Loading Verovio for the first time...')
                     $.getScript( "https://www.verovio.org/javascript/latest/verovio-toolkit.js", function( data, textStatus, jqxhr ) {
@@ -655,7 +656,8 @@
                 $("#buttonDerivativeContinuo").text("Hide music notation")
                 $("#collapseDerivativeContinuo").collapse('hide')
                 MEIurl = $("#derivative-piece option:selected").data('piece-url')
-                // MEIurl = MEIurl.replace('https://crim', 'https://dev.crim')
+                // XXX: Use this line for local development only
+                // MEIurl = MEIurl.replace('https://crimproject.org/mei/', 'http://127.0.0.1:8000/static/mei/MEI_4.0/')
                 if (!ver) {
                     console.log('Loading Verovio for the first time...')
                     $.getScript( "https://www.verovio.org/javascript/latest/verovio-toolkit.js", function( data, textStatus, jqxhr ) {


### PR DESCRIPTION
Updated continuo.js with correct verovio api call.
I have updated the continuo.js file which seems to be a precompiled version of the library from here:
https://github.com/umd-mith/continuo
which seems to be old as the last update to the project was 2019; however, oddly I cannot seem to find reference to any `renderPage` function in the Veriovio documentation:
https://book.verovio.org/toolkit-reference/toolkit-methods.html
even looking through some of the source history I cannot find this method, so I am uncertain as to how this functioned previously.
Please review this update and let me know if any of the rendering functionality is no longer acting as it used to.